### PR TITLE
Fixes for vs2010 and other minor things

### DIFF
--- a/Lakeshore340Sup/lakeshore340excitations.h
+++ b/Lakeshore340Sup/lakeshore340excitations.h
@@ -1,5 +1,4 @@
 #include <registryFunction.h>
-#include <epicsExport.h>
 #include <aSubRecord.h>
 #include <errlog.h>
 
@@ -8,13 +7,13 @@ extern "C" {
 #endif
 
 typedef struct {
-  char *excitationString;
+  const char *excitationString;
   epicsEnum16 excitationValue;
 } excitationStringValuePair;
 
 // excitation mbbi string and enum value pairs
 // If changing the values here also change the values in the Lakeshore340.db file
-static excitationStringValuePair excitation_string_to_val_map[] = {
+static const excitationStringValuePair excitation_string_to_val_map[] = {
     {"Off", 0}, {"30 nA", 1}, {"100 nA", 2}, {"300 nA", 3}, {"1 uA", 4},
     {"3 uA", 5}, {"10 uA", 6}, {"30 uA", 7}, {"100 uA", 8}, {"300 uA", 9},
     {"1 mA", 10}, {"10 mV", 11}, {"1 mV", 12}
@@ -29,12 +28,12 @@ typedef struct {
     epicsEnum16 excitation;
 } thresholdTempExcitationPair;
 
-bool tempExcitationPairValid(thresholdTempExcitationPair pair);
-thresholdTempExcitationPair getThresholdTempExcitationPairFromLine(char *line);
-epicsEnum16 getEnumFromString(char * enumAsString);
-thresholdTempExcitationPair getExcitationPairIfConditionsMatch(char *line, epicsFloat64 tempSp, thresholdTempExcitationPair tempExcitationPair);
+int tempExcitationPairValid(thresholdTempExcitationPair pair);
+thresholdTempExcitationPair getThresholdTempExcitationPairFromLine(const char *line);
+epicsEnum16 getEnumFromString(const char * enumAsString);
+thresholdTempExcitationPair getExcitationPairIfConditionsMatch(const char *line, epicsFloat64 tempSp, thresholdTempExcitationPair tempExcitationPair);
 thresholdTempExcitationPair getLargestTempExcitationPairFromFileThatIsLessThanTempSp(FILE *thresholdsFile, epicsFloat64 tempSp);
-thresholdTempExcitationPair getInvalidThresholdTempExcitationPair();
+thresholdTempExcitationPair getInvalidThresholdTempExcitationPair(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Fix building on VS2010 (bool not supported), also other minor tidy up.

@JamesKingWork I noticed the db file used `field(FTE,  "INT64")` but the code uses ` *(epicsInt8*)prec->e` - which size should the field be?

